### PR TITLE
move salt-api to port 8088

### DIFF
--- a/classes/cluster/k8s-salt-model/infra/init.yml
+++ b/classes/cluster/k8s-salt-model/infra/init.yml
@@ -4,6 +4,7 @@ parameters:
     salt_control_trusty_image: http://apt.tcpcloud.eu/images/ubuntu-14-04-x64-201612140957.qcow2
     salt_control_xenial_image: http://apt.tcpcloud.eu/images/ubuntu-16-04-x64-201612140953.qcow2
     salt_api_password_hash: "$6$WV0P1shnoDh2gI/Z$22/Bcd7ffMv0jDlFpT63cAU4PiXHz9pjXwngToKwqAsgoeK4HNR3PiKaushjxp3JsQ8hNoJmAC6TxzVqfV8WH/"
+    salt_master_api_port: 8088
   linux:
     network:
       host:


### PR DESCRIPTION
Port 8088 is used in all MK labs and we should use same port.