### PR TITLE
enable helm and netchecker addons as a default

### DIFF
--- a/classes/cluster/k8s-salt-model/kubernetes/control.yml
+++ b/classes/cluster/k8s-salt-model/kubernetes/control.yml
@@ -30,3 +30,11 @@ parameters:
         etcd:
           ssl:
             enabled: true
+      namespace:
+        netchecker:
+          enabled: true
+      addons:
+        netchecker:
+          enabled: true
+        helm:
+          enabled: true


### PR DESCRIPTION
Netchecker is very apprecitated by QA, they use it and so we decided to enable it by default. 

However, it shouldn't be ported to cookiecutter.