### PR TITLE
set docker package version

### DIFF
--- a/classes/cluster/k8s-salt-model/kubernetes/compute.yml
+++ b/classes/cluster/k8s-salt-model/kubernetes/compute.yml
@@ -6,6 +6,11 @@ classes:
 #- system.bird.server.single
 - cluster.k8s-salt-model
 parameters:
+  docker:
+    host:
+      pkgs:
+        - docker-engine=1.12.6-0~ubuntu-xenial
+        - python-docker
   kubernetes:
     pool:
       network:


### PR DESCRIPTION
Latest docker version verified for Kubernetes is 1.12.6.

We should pin this version of `docker-engine`